### PR TITLE
Enhance Tier 1 state styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -323,7 +323,8 @@ def upload_form():
                 'fillColor': TIER_COLORS.get(feat['properties']['CaaS Tier'], 'gray'),
                 'color': 'black',
                 'weight': 1,
-                'fillOpacity': 1.0
+                'fillOpacity': 1.0,
+                'className': 'tier1-state' if feat['properties'].get('CaaS Tier') == 'Tier 1' else ''
             },
             tooltip=folium.features.GeoJsonTooltip(fields=['name'], aliases=['State:'])
         ).add_to(m)
@@ -688,6 +689,11 @@ def upload_form():
             border: none;
             box-shadow: 5px 5px 10px #666;
             padding: 0;
+        }
+
+        /* 3D effect for Tier 1 states */
+        .tier1-state {
+            filter: drop-shadow(2px 2px 3px rgba(0, 0, 0, 0.5));
         }
         </style>
         """


### PR DESCRIPTION
## Summary
- highlight Tier 1 states by assigning them a special CSS class
- add CSS rule for a drop-shadow to create a 3D effect

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685ab8d70e0083229fbde4182d1247f5