### PR TITLE
Improve label collision and add PowerPoint export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ folium
 shapely
 geopy
 openpyxl
+python-pptx


### PR DESCRIPTION
## Summary
- fix storing tooltip offsets so collision logic no longer errors
- add ability to export a PPT slide that links to the generated map
- include `python-pptx` in requirements

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685adc22556083228728d15eb4ee4875