### PR TITLE
Fix group 1 pop‑out effect and embed map in PPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This project provides a small Flask application for generating interactive maps 
 - Choose different pin styles for the map markers.
 - Group US states by electrification parity probability (using the data in `input_csv_files/group_by_state.csv`).
 - Save the generated map to `static/maps` and open it in the browser.
-- Optionally download a PowerPoint slide that links to the generated map.
+- Optionally download a PowerPoint slide that attempts to embed the map so you
+  can interact with it directly in the slide (falls back to a hyperlink if
+  embedding isn't supported).
 
 ## Installation
 

--- a/app.py
+++ b/app.py
@@ -748,7 +748,10 @@ def upload_form():
 
         /* Base style for Group 1 states */
         .group1-state {
-            filter: brightness(1.05);
+            filter:
+                brightness(1.05)
+                drop-shadow(-2px -2px 3px rgba(255, 255, 255, 0.8))
+                drop-shadow(6px 6px 8px rgba(0, 0, 0, 0.7));
         }
 
         /* Pronounced shadow for combined Group 1 regions */
@@ -808,12 +811,27 @@ def download_ppt(map_id):
     slide = prs.slides.add_slide(prs.slide_layouts[5])
     title = slide.shapes.title
     title.text = "Interactive Map"
-    box = slide.shapes.add_textbox(Inches(1), Inches(2), Inches(8), Inches(1))
-    tf = box.text_frame
-    p = tf.paragraphs[0]
-    run = p.add_run()
-    run.text = "Open Map"
-    run.hyperlink.address = link
+
+    try:
+        # Attempt to embed the HTML map directly as an OLE object so it can be
+        # interacted with when the slide is presented.  This requires PowerPoint
+        # on Windows and may not function on other platforms.
+        slide.shapes.add_ole_object(
+            html_path,
+            prog_id="htmlfile",
+            left=Inches(0.5),
+            top=Inches(1.5),
+            width=Inches(9),
+            height=Inches(5),
+        )
+    except Exception:
+        # Fallback: just provide a hyperlink if embedding fails
+        box = slide.shapes.add_textbox(Inches(1), Inches(2), Inches(8), Inches(1))
+        tf = box.text_frame
+        p = tf.paragraphs[0]
+        run = p.add_run()
+        run.text = "Open Map"
+        run.hyperlink.address = link
 
     ppt_filename = f"{map_id}.pptx"
     ppt_path = os.path.join("static", "maps", ppt_filename)


### PR DESCRIPTION
## Summary
- tweak label for map group 1 states so they pop out
- attempt to embed the generated map in the PowerPoint slide
- update README to mention the new PPT embedding behaviour

## Testing
- `python app.py -m`

------
https://chatgpt.com/codex/tasks/task_e_685af4c815d48322a00ac6fd039fac4a